### PR TITLE
fix(minifier): harden UBO namespace check

### DIFF
--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -64,7 +64,13 @@ export function minify(
         // Skip struct properties
         blockIndex == null &&
         // Is declaration, reference, namespace, or comma-separated list
-        (isName(tokens[i - 1]?.value) || /}|,/.test(tokens[i - 1]?.value) || tokens[i + 1]?.value === ':') &&
+        (isName(tokens[i - 1]?.value) ||
+          // uniform Type { ... } name;
+          (tokens[i - 1]?.value === '}' && tokens[i + 1]?.value === ';') ||
+          // float foo, bar;
+          tokens[i - 1]?.value === ',' ||
+          // fn (arg: type) -> void
+          tokens[i + 1]?.value === ':') &&
         // Skip shader externals when disabled
         (mangleExternals || (!isStorage(tokens[i - 1]?.value) && !isStorage(tokens[i - 2]?.value)))
       ) {

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -10,7 +10,7 @@ const bool c=true;
 #endif
 uniform float foo,bar;uniform sampler2D map;in vec2 vUv;out vec4 pc_FragColor;
 #include <three_test>
-layout(std140)uniform Uniforms1{mat4 projectionMatrix;mat4 modelViewMatrix;mat3 normalMatrix;float one,two;};layout(std140)uniform Uniforms2{mat4 projectionMatrix;mat4 modelViewMatrix;mat3 normalMatrix;float one,two;}d;struct e{float intensity;vec3 position;float one,two;};uniform e Light[4];void main(){vec4 f=vec4(Light[0].position.xyz*Light[0].intensity,0.0);vec4 g=projectionMatrix*modelViewMatrix*vec4(0,0,0,1);vec4 h=d.projectionMatrix*d.modelViewMatrix*vec4(0,0,0,1);pc_FragColor=vec4(texture(map,vUv).rgb,0.0);pc_FragColor.a+=1.0;}"
+layout(std140)uniform Uniforms1{mat4 projectionMatrix;mat4 modelViewMatrix;mat3 normalMatrix;float one,two;};layout(std140)uniform Uniforms2{mat4 projectionMatrix;mat4 modelViewMatrix;mat3 normalMatrix;float one,two;}d;struct e{float intensity;vec3 position;float one,two;};uniform e Light[4];void main(){vec4 f=vec4(Light[0].position.xyz*Light[0].intensity,0.0);vec4 g=projectionMatrix*modelViewMatrix*vec4(0,0,0,1);vec4 h=d.projectionMatrix*d.modelViewMatrix*vec4(0,0,0,1);if(false){}pc_FragColor=vec4(texture(map,vUv).rgb,0.0);pc_FragColor.a+=1.0;}"
 `;
 
 exports[`minify > can mangle WGSL 1`] = `"struct a{intensity:f32,position:vec3<f32>,one:f32,two:f32,};struct b{projectionMatrix:mat4x4<f32>,modelViewMatrix:mat4x4<f32>,normalMatrix:mat3x3<f32>,one:f32,two:f32,lights:array<a,4>,};@binding(0)@group(0)var<uniform>uniforms:b;@binding(1)@group(0)var sample:sampler;@binding(2)@group(0)var c:texture_2d<f32>;struct d{@location(0)position:vec4<f32>,@location(1)uv:vec2<f32>,};struct e{@builtin(position)position:vec4<f32>,@location(0)uv:vec2<f32>,};@vertex fn f(g:d)->e{var output:e;output.position=g.position;output.uv=g.uv;return output;}@fragment fn h(i:vec2<f32>)->vec4<f32>{var j=vec4<f32>(uniforms.lights[0].position*uniforms.lights[0].intensity,0.0);var k=uniforms.projectionMatrix*uniforms.modelViewMatrix*vec4<f32>(0.0,0.0,0.0,1.0);var l=textureSample(c,sample,i);l.a+=1.0;return l;}"`;
@@ -25,7 +25,7 @@ const bool c=true;
 #endif
 uniform float d,e;uniform sampler2D f;in vec2 g;out vec4 h;
 #include <three_test>
-layout(std140)uniform i{mat4 projectionMatrix;mat4 modelViewMatrix;mat3 normalMatrix;float one,two;};layout(std140)uniform j{mat4 projectionMatrix;mat4 modelViewMatrix;mat3 normalMatrix;float one,two;}k;struct l{float intensity;vec3 position;float one,two;};uniform l m[4];void main(){vec4 n=vec4(m[0].position.xyz*m[0].intensity,0.0);vec4 o=projectionMatrix*modelViewMatrix*vec4(0,0,0,1);vec4 p=k.projectionMatrix*k.modelViewMatrix*vec4(0,0,0,1);h=vec4(texture(f,g).rgb,0.0);h.a+=1.0;}"
+layout(std140)uniform i{mat4 projectionMatrix;mat4 modelViewMatrix;mat3 normalMatrix;float one,two;};layout(std140)uniform j{mat4 projectionMatrix;mat4 modelViewMatrix;mat3 normalMatrix;float one,two;}k;struct l{float intensity;vec3 position;float one,two;};uniform l m[4];void main(){vec4 n=vec4(m[0].position.xyz*m[0].intensity,0.0);vec4 o=projectionMatrix*modelViewMatrix*vec4(0,0,0,1);vec4 p=k.projectionMatrix*k.modelViewMatrix*vec4(0,0,0,1);if(false){}h=vec4(texture(f,g).rgb,0.0);h.a+=1.0;}"
 `;
 
 exports[`minify > can mangle externals in WGSL 1`] = `"struct a{intensity:f32,position:vec3<f32>,one:f32,two:f32,};struct b{projectionMatrix:mat4x4<f32>,modelViewMatrix:mat4x4<f32>,normalMatrix:mat3x3<f32>,one:f32,two:f32,lights:array<a,4>,};@binding(0)@group(0)var<uniform>c:b;@binding(1)@group(0)var sample:sampler;@binding(2)@group(0)var d:texture_2d<f32>;struct e{@location(0)position:vec4<f32>,@location(1)uv:vec2<f32>,};struct f{@builtin(position)position:vec4<f32>,@location(0)uv:vec2<f32>,};@vertex fn g(h:e)->f{var output:f;output.position=h.position;output.uv=h.uv;return output;}@fragment fn i(j:vec2<f32>)->vec4<f32>{var k=vec4<f32>(c.lights[0].position*c.lights[0].intensity,0.0);var l=c.projectionMatrix*c.modelViewMatrix*vec4<f32>(0.0,0.0,0.0,1.0);var m=textureSample(d,sample,j);m.a+=1.0;return m;}"`;
@@ -58,7 +58,7 @@ const bool isTest=true;
 #endif
 uniform float foo,bar;uniform sampler2D map;in vec2 vUv;out vec4 pc_FragColor;
 #include <three_test>
-layout(std140)uniform Uniforms1{mat4 projectionMatrix;mat4 modelViewMatrix;mat3 normalMatrix;float one,two;};layout(std140)uniform Uniforms2{mat4 projectionMatrix;mat4 modelViewMatrix;mat3 normalMatrix;float one,two;}globals;struct LightData{float intensity;vec3 position;float one,two;};uniform LightData Light[4];void main(){vec4 lightNormal=vec4(Light[0].position.xyz*Light[0].intensity,0.0);vec4 clipPosition=projectionMatrix*modelViewMatrix*vec4(0,0,0,1);vec4 clipPositionGlobals=globals.projectionMatrix*globals.modelViewMatrix*vec4(0,0,0,1);pc_FragColor=vec4(texture(map,vUv).rgb,0.0);pc_FragColor.a+=1.0;}"
+layout(std140)uniform Uniforms1{mat4 projectionMatrix;mat4 modelViewMatrix;mat3 normalMatrix;float one,two;};layout(std140)uniform Uniforms2{mat4 projectionMatrix;mat4 modelViewMatrix;mat3 normalMatrix;float one,two;}globals;struct LightData{float intensity;vec3 position;float one,two;};uniform LightData Light[4];void main(){vec4 lightNormal=vec4(Light[0].position.xyz*Light[0].intensity,0.0);vec4 clipPosition=projectionMatrix*modelViewMatrix*vec4(0,0,0,1);vec4 clipPositionGlobals=globals.projectionMatrix*globals.modelViewMatrix*vec4(0,0,0,1);if(false){}pc_FragColor=vec4(texture(map,vUv).rgb,0.0);pc_FragColor.a+=1.0;}"
 `;
 
 exports[`minify > can minify WGSL 1`] = `"struct LightData{intensity:f32,position:vec3<f32>,one:f32,two:f32,};struct Uniforms{projectionMatrix:mat4x4<f32>,modelViewMatrix:mat4x4<f32>,normalMatrix:mat3x3<f32>,one:f32,two:f32,lights:array<LightData,4>,};@binding(0)@group(0)var<uniform>uniforms:Uniforms;@binding(1)@group(0)var sample:sampler;@binding(2)@group(0)var map:texture_2d<f32>;struct VertexIn{@location(0)position:vec4<f32>,@location(1)uv:vec2<f32>,};struct VertexOut{@builtin(position)position:vec4<f32>,@location(0)uv:vec2<f32>,};@vertex fn vert_main(input:VertexIn)->VertexOut{var output:VertexOut;output.position=input.position;output.uv=input.uv;return output;}@fragment fn frag_main(uv:vec2<f32>)->vec4<f32>{var lightNormal=vec4<f32>(uniforms.lights[0].position*uniforms.lights[0].intensity,0.0);var clipPosition=uniforms.projectionMatrix*uniforms.modelViewMatrix*vec4<f32>(0.0,0.0,0.0,1.0);var color=textureSample(map,sample,uv);color.a+=1.0;return color;}"`;
@@ -1436,6 +1436,43 @@ exports[`tokenize > can tokenize GLSL 1`] = `
   {
     "type": "symbol",
     "value": ";",
+  },
+  {
+    "type": "whitespace",
+    "value": "
+    ",
+  },
+  {
+    "type": "keyword",
+    "value": "if",
+  },
+  {
+    "type": "whitespace",
+    "value": " ",
+  },
+  {
+    "type": "symbol",
+    "value": "(",
+  },
+  {
+    "type": "bool",
+    "value": "false",
+  },
+  {
+    "type": "symbol",
+    "value": ")",
+  },
+  {
+    "type": "whitespace",
+    "value": " ",
+  },
+  {
+    "type": "symbol",
+    "value": "{",
+  },
+  {
+    "type": "symbol",
+    "value": "}",
   },
   {
     "type": "whitespace",

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -51,6 +51,7 @@ const glsl = /* glsl */ `#version 300 es
     vec4 lightNormal = vec4(Light[0].position.xyz * Light[0].intensity, 0.0);
     vec4 clipPosition = projectionMatrix * modelViewMatrix * vec4(0, 0, 0, 1);
     vec4 clipPositionGlobals = globals.projectionMatrix * globals.modelViewMatrix * vec4(0, 0, 0, 1);
+    if (false) {}
     pc_FragColor = vec4(texture(map, vUv).rgb, 0.0);
     pc_FragColor.a += 1.0;
   }


### PR DESCRIPTION
Fixes #7 where identifiers after a brace were mangled as if they were namespace identifiers (GLSL).