### PR TITLE
fix(minify): handle mangleMap collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,6 @@ const programOpts = { mangle: true, mangleExternals: true, mangleMap: new Map() 
 // #version 300 es\nin vec2 a;out vec2 b;void main(){b=a;}
 minify(`#version 300 es\nin vec2 uv;out vec2 c;void main(){c=uv;}`, programOpts)
 
-// #version 300 es\nin vec2 b;out vec4 c[gl_MaxDrawBuffers];void main(){c[0]=b.sstt;}
+// #version 300 es\nin vec2 b;out vec4 a[gl_MaxDrawBuffers];void main(){a[0]=b.sstt;}
 minify(`#version 300 es\nin vec2 c;out vec4 data[gl_MaxDrawBuffers];void main(){data[0]=c.sstt;}`, programOpts)
 ```

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -26,7 +26,6 @@ export function minify(
   // Escape newlines after directives, skip comments
   code = code.replace(/(^\s*#[^\\]*?)(\n|\/[\/\*])/gm, '$1\\$2')
 
-  const exclude = new Set<string>(mangleMap.values())
   const tokens: Token[] = tokenize(code).filter((token) => token.type !== 'whitespace' && token.type !== 'comment')
 
   let mangleIndex: number = 0
@@ -74,7 +73,7 @@ export function minify(
         // Skip shader externals when disabled
         (mangleExternals || (!isStorage(tokens[i - 1]?.value) && !isStorage(tokens[i - 2]?.value)))
       ) {
-        while (!renamed || exclude.has(renamed)) {
+        while (!renamed) {
           renamed = ''
           mangleIndex++
 
@@ -83,6 +82,8 @@ export function minify(
             renamed = String.fromCharCode(97 + ((j - 1) % 26)) + renamed
             j = Math.floor(j / 26)
           }
+
+          if (!mangleMap.has(renamed)) break
         }
 
         mangleMap.set(token.value, renamed)

--- a/src/minifier.ts
+++ b/src/minifier.ts
@@ -14,7 +14,7 @@ export interface MinifyOptions {
 const isWord = RegExp.prototype.test.bind(/^\w/)
 const isSymbol = RegExp.prototype.test.bind(/[^\w\\]/)
 const isName = RegExp.prototype.test.bind(/^[_A-Za-z]/)
-const isStorage = RegExp.prototype.test.bind(/^(@|layout|uniform|in|out|attribute|varying)$/)
+const isStorage = RegExp.prototype.test.bind(/^(binding|group|layout|uniform|in|out|attribute|varying)$/)
 
 /**
  * Minifies a string of GLSL or WGSL code.
@@ -36,7 +36,7 @@ export function minify(
     const token = tokens[i]
 
     // Track newlines' offsets
-    if (/[;{}\\]|^fn$/.test(token.value)) lineIndex = i + 1
+    if (/[;{}\\@]/.test(token.value)) lineIndex = i + 1
 
     // Mark enter/leave block-scope
     if (token.value === '{' && isName(tokens[i - 1]?.value)) blockIndex = i - 1

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -26,22 +26,21 @@ Map {
 }
 `;
 
-exports[`minify > can mangle WGSL 1`] = `"struct a{intensity:f32,position:vec3<f32>,one:f32,two:f32,};struct b{projectionMatrix:mat4x4<f32>,modelViewMatrix:mat4x4<f32>,normalMatrix:mat3x3<f32>,one:f32,two:f32,lights:array<a,4>,};@binding(0)@group(0)var<uniform>uniforms:b;@binding(1)@group(0)var sample:sampler;@binding(2)@group(0)var c:texture_2d<f32>;struct d{@location(0)position:vec4<f32>,@location(1)uv:vec2<f32>,};struct e{@builtin(position)position:vec4<f32>,@location(0)uv:vec2<f32>,};@vertex fn f(g:d)->e{var output:e;output.position=g.position;output.uv=g.uv;return output;}@fragment fn h(i:vec2<f32>)->vec4<f32>{var j=vec4<f32>(uniforms.lights[0].position*uniforms.lights[0].intensity,0.0);var k=uniforms.projectionMatrix*uniforms.modelViewMatrix*vec4<f32>(0.0,0.0,0.0,1.0);var l=textureSample(c,sample,i);l.a+=1.0;return l;}"`;
+exports[`minify > can mangle WGSL 1`] = `"struct a{intensity:f32,position:vec3<f32>,one:f32,two:f32,};struct b{projectionMatrix:mat4x4<f32>,modelViewMatrix:mat4x4<f32>,normalMatrix:mat3x3<f32>,one:f32,two:f32,lights:array<a,4>,};@binding(0)@group(0)var<uniform>uniforms:Uniforms;@binding(1)@group(0)var sample:sampler;@binding(2)@group(0)var map:texture_2d<f32>;struct c{@location(0)position:vec4<f32>,@location(1)uv:vec2<f32>,};struct d{@builtin(position)position:vec4<f32>,@location(0)uv:vec2<f32>,};@vertex fn e(f:c)->d{var output:d;output.position=f.position;output.uv=f.uv;return output;}@fragment fn g(h:vec2<f32>)->vec4<f32>{var i=vec4<f32>(uniforms.lights[0].position*uniforms.lights[0].intensity,0.0);var j=uniforms.projectionMatrix*uniforms.modelViewMatrix*vec4<f32>(0.0,0.0,0.0,1.0);var k=textureSample(map,sample,h);k.a+=1.0;return k;}"`;
 
 exports[`minify > can mangle WGSL 2`] = `
 Map {
   "LightData" => "a",
   "Uniforms" => "b",
-  "map" => "c",
-  "VertexIn" => "d",
-  "VertexOut" => "e",
-  "vert_main" => "f",
-  "input" => "g",
-  "frag_main" => "h",
-  "uv" => "i",
-  "lightNormal" => "j",
-  "clipPosition" => "k",
-  "color" => "l",
+  "VertexIn" => "c",
+  "VertexOut" => "d",
+  "vert_main" => "e",
+  "input" => "f",
+  "frag_main" => "g",
+  "uv" => "h",
+  "lightNormal" => "i",
+  "clipPosition" => "j",
+  "color" => "k",
 }
 `;
 

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -99,17 +99,17 @@ Map {
 }
 `;
 
-exports[`minify > can mangle multiple GLSL shaders with collisions 1`] = `
+exports[`minify > can mangle multiple GLSL shaders 1`] = `
 "#version 300 es
 in vec2 a;out vec2 b;void main(){b=a;}"
 `;
 
-exports[`minify > can mangle multiple GLSL shaders with collisions 2`] = `
+exports[`minify > can mangle multiple GLSL shaders 2`] = `
 "#version 300 es
 in vec2 b;out vec4 c[gl_MaxDrawBuffers];void main(){c[0]=b.sstt;}"
 `;
 
-exports[`minify > can mangle multiple GLSL shaders with collisions 3`] = `
+exports[`minify > can mangle multiple GLSL shaders 3`] = `
 Map {
   "uv" => "a",
   "c" => "b",
@@ -189,6 +189,16 @@ Map {
   "u50" => "ay",
   "u51" => "bz",
   "u52" => "ba",
+}
+`;
+
+exports[`minify > handles mangleMap collisions 1`] = `"uniform float a;c.xyz=vec3(0);"`;
+
+exports[`minify > handles mangleMap collisions 2`] = `
+Map {
+  "a" => "b",
+  "c" => "d",
+  "xyz" => "e",
 }
 `;
 

--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -106,14 +106,14 @@ in vec2 a;out vec2 b;void main(){b=a;}"
 
 exports[`minify > can mangle multiple GLSL shaders 2`] = `
 "#version 300 es
-in vec2 b;out vec4 c[gl_MaxDrawBuffers];void main(){c[0]=b.sstt;}"
+in vec2 b;out vec4 a[gl_MaxDrawBuffers];void main(){a[0]=b.sstt;}"
 `;
 
 exports[`minify > can mangle multiple GLSL shaders 3`] = `
 Map {
   "uv" => "a",
   "c" => "b",
-  "data" => "c",
+  "data" => "a",
 }
 `;
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -156,7 +156,7 @@ describe('minify', () => {
     expect(mangleMap).toMatchSnapshot()
   })
 
-  it('can mangle multiple GLSL shaders with collisions', () => {
+  it('can mangle multiple GLSL shaders', () => {
     const mangleMap = new Map()
     const vert = /* glsl */ `#version 300 es\nin vec2 uv;out vec2 c;void main(){c=uv;}`
     const frag = /* glsl */ `#version 300 es\nin vec2 c;out vec4 data[gl_MaxDrawBuffers];void main(){data[0]=c.sstt;}`
@@ -170,6 +170,18 @@ describe('minify', () => {
     const mangleMap = new Map()
     const shader = /* glsl */ `float ${Array.from({ length: 53 }, (_, i) => `u${i}`)}`
     expect(minify(shader, { mangle: true, mangleExternals: true, mangleMap })).toMatchSnapshot()
+    expect(mangleMap).toMatchSnapshot()
+  })
+
+  it('handles mangleMap collisions', () => {
+    const mangleMap = new Map([
+      ['a', 'b'],
+      ['c', 'd'],
+      ['xyz', 'e'],
+    ])
+    const shader = /* glsl */ `uniform float a;c.xyz=vec3(0);`
+
+    expect(minify(shader, { mangle: true, mangleExternals: false, mangleMap })).toMatchSnapshot()
     expect(mangleMap).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
Fixes #8 where entries in `mangleMap` will incorrectly override mangle settings and create invalid syntax.