### PR TITLE
fix: add WebGL1 keywords for three.js

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -813,6 +813,21 @@ export const GLSL_KEYWORDS = [
   // Additional directives
   '#include',
 
+  // WebGL1 (three.js)
+  // 'attribute',
+  // 'varying',
+  'gl_FragColor',
+  'gl_FragDepthEXT',
+  'texture2D',
+  'textureCube',
+  'texture2DProj',
+  'texture2DLodEXT',
+  'texture2DProjLodEXT',
+  'textureCubeLodEXT',
+  'texture2DGradEXT',
+  'texture2DProjGradEXT',
+  'textureCubeGradEXT',
+
   // WEBGL_multi_draw https://registry.khronos.org/webgl/extensions/WEBGL_multi_draw
   'gl_DrawID', // vertex only
 


### PR DESCRIPTION
Adds WebGL1 keywords three.js uses in [mrdoob/three.js/src/renderers/webgl/WebGLProgram.js#L864](https://github.com/mrdoob/three.js/blob/a7500fdc0c87acb219777e26bba9e1013b9786d5/src/renderers/webgl/WebGLProgram.js#L864) to recognized reserved words https://github.com/CodyJasonBennett/shaderkit/issues/21#issue-2262125799.

This list may not be exhaustive, but it is best effort considering this compiler can only feasibly target GLSL ES 3+ and WGSL. These will not be validated by the parser and may report errors when explicitly specifying a GLSL version (three.js omits this header).