### PR TITLE
fix(parser): handle preprocessor in struct declarations

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -427,7 +427,7 @@ function parseStruct(tokens: Token[]): StructDeclaration {
   consume(tokens, '{')
   const members: VariableDeclaration[] = []
   while (tokens[0] && tokens[0].value !== '}') {
-    members.push(parseIndeterminate(tokens) as VariableDeclaration)
+    members.push(...(parseStatements(tokens) as unknown as VariableDeclaration[]))
   }
   consume(tokens, '}')
   consume(tokens, ';')

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -40,13 +40,13 @@ const glsl = /* glsl */ `#version 300 es
     float one, two;
   } globals;
 
-  // struct X {
-  //   #if !defined(BLA)
-  //     int y;
-  //   #else
-  //     float z;
-  //   #endif
-  // };
+  struct X {
+    #if !defined(BLA)
+      int y;
+    #else
+      float z;
+    #endif
+  };
 
   struct LightData {
     float intensity;


### PR DESCRIPTION
Handles preprocessor statements within struct declarations like the following:

```c
struct X {
  #if !defined(BLA)
    int y;
  #else
    float z;
  #endif
};
```

The AST is not yet updated to reflect this case, but I expect preprocessor unfolding needs to be revisited.