### PR TITLE
fix: add main key for Bundlephobia resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "src/*"
   ],
   "type": "module",
+  "main": "./dist/index.js",
   "exports": "./dist/index.js",
   "sideEffects": false,
   "devDependencies": {


### PR DESCRIPTION
Adds the package main field so Bundlephobia resolves this package. This is non-standard behavior and the exports field should take precedence, but there is a mix of incorrect Webpack 4 and partial Node ESM support in there.