### PR TITLE
feat: Support for WebGL 1 layout syntax

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -274,7 +274,7 @@ export interface ForStatement extends Node {
 
 export type ConstantQualifier = 'const'
 export type ParameterQualifier = 'in' | 'out' | 'inout'
-export type StorageQualifier = 'uniform' | 'in' | 'out'
+export type StorageQualifier = 'uniform' | 'in' | 'out' | 'attribute' | 'varying'
 export type InterfaceStorageQualifier = 'uniform' | 'buffer'
 export type MemoryQualifier = 'coherent' | 'volatile' | 'restrict' | 'readonly' | 'writeonly'
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -119,7 +119,7 @@ const INFIX_OPERATOR_PRECEDENCE_RIGHT: Record<string, Precedence> = {
 }
 
 const QUALIFIER_REGEX =
-  /^(const|buffer|uniform|in|out|inout|centroid|flat|smooth|invariant|lowp|mediump|highp|coherent|volatile|restrict|readonly|writeonly)$/
+  /^(const|buffer|uniform|in|out|inout|centroid|flat|smooth|invariant|lowp|mediump|highp|coherent|volatile|restrict|readonly|writeonly|attribute|varying)$/
 
 const SCOPE_DELTAS: Record<string, number> = {
   // Open

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -260,4 +260,18 @@ describe('generator', () => {
     const output = generate(program, { target: 'GLSL' })
     expect(output).toBe(minify(compute))
   })
+
+  it('can generate attribute variable declarations', () => {
+    const shader = 'attribute vec4 position;'
+    const program = parse(shader)
+    const output = generate(program, { target: 'GLSL' })
+    expect(output).toBe('attribute vec4 position;')
+  })
+
+  it('can generate varying variable declarations', () => {
+    const shader = 'varying vec3 normal;'
+    const program = parse(shader)
+    const output = generate(program, { target: 'GLSL' })
+    expect(output).toBe('varying vec3 normal;')
+  })
 })

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -318,6 +318,50 @@ describe('parser', () => {
       },
     ])
 
+    expect(parse('attribute vec4 position;').body).toStrictEqual<[VariableDeclaration]>([
+      {
+        declarations: [
+          {
+            id: {
+              name: 'position',
+              type: 'Identifier',
+            },
+            init: null,
+            layout: null,
+            qualifiers: ['attribute'],
+            type: 'VariableDeclarator',
+            typeSpecifier: {
+              name: 'vec4',
+              type: 'Identifier',
+            },
+          },
+        ],
+        type: 'VariableDeclaration',
+      },
+    ])
+
+    expect(parse('varying vec3 normal;').body).toStrictEqual<[VariableDeclaration]>([
+      {
+        declarations: [
+          {
+            id: {
+              name: 'normal',
+              type: 'Identifier',
+            },
+            init: null,
+            layout: null,
+            qualifiers: ['varying'],
+            type: 'VariableDeclarator',
+            typeSpecifier: {
+              name: 'vec3',
+              type: 'Identifier',
+            },
+          },
+        ],
+        type: 'VariableDeclaration',
+      },
+    ])
+
     expect(parse('const vec4 foo = vec4(0, 0, 0, 0);').body).toStrictEqual<[VariableDeclaration]>([
       {
         declarations: [


### PR DESCRIPTION
Hi! 👋

Since there seem to be a lot of projects still on WebGL 1, could we support the old layout syntax (attribute / varying)? I'm trying to use shaderkit for a project that covers both WebGL 1 and WebGL 2 codebases.