### PR TITLE
fix: Member precedence

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -216,7 +216,7 @@ function parseExpression(tokens: Token[], minBindingPower: number = 0): Expressi
           lhs = { type: 'MemberExpression', object: lhs, property: rhs!, computed: true }
         }
       } else if (token.value === '.') {
-        const rhs = parseExpression(tokens, 0)
+        const rhs = parseExpression(tokens, leftBindingPower)
         lhs = { type: 'MemberExpression', object: lhs, property: rhs, computed: false }
       } else if (token.value === '--' || token.value === '++') {
         lhs = { type: 'UpdateExpression', operator: token.value as UpdateOperator, prefix: false, argument: lhs }

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -236,10 +236,14 @@ describe('parser', () => {
       {
         type: 'ExpressionStatement',
         expression: {
-          type: 'MemberExpression',
-          object: { type: 'Identifier', name: 'array' },
-          property: { type: 'CallExpression', callee: { type: 'Identifier', name: 'length' }, arguments: [] },
-          computed: false,
+          type: 'CallExpression',
+          callee: {
+            type: 'MemberExpression',
+            object: { type: 'Identifier', name: 'array' },
+            property: { type: 'Identifier', name: 'length' },
+            computed: false,
+          },
+          arguments: [],
         },
       },
     ])

--- a/tests/precedence.test.ts
+++ b/tests/precedence.test.ts
@@ -70,6 +70,7 @@ colRel = vec3(float(rel1), float(rel2), float(rel3));
 colLog = vec3(float(log1), float(log2), float(log3));
 colTern = vec3((tern1 + tern2) / 20.0, 0.5, 0.0);
 colBits = vec3(float(bit1 & 1), float(bit2 & 1), float(bit3 & 1));
+member1 = vec.x + 1 + 2;
 `.trim()
 
 const grouped = /* glsl */ `
@@ -95,6 +96,7 @@ colRel = vec3(float(rel1), float(rel2), float(rel3));
 colLog = vec3(float(log1), float(log2), float(log3));
 colTern = vec3((tern1 + tern2) / 20.0, 0.5, 0.0);
 colBits = vec3(float(bit1 & 1), float(bit2 & 1), float(bit3 & 1));
+member1 = ((vec.x + 1) + 2);
 `.trim()
 
 describe('parser', () => {


### PR DESCRIPTION
Not sure if it's a general patch that can be applied to everything, but in terms of member access, following operations were taking precedence over it, even though it should have higher precedence.

 Before:
<img width="871" height="252" alt="Screenshot 2025-08-28 at 21 21 01" src="https://github.com/user-attachments/assets/7a0031ec-1b86-4a62-8121-658e082b333a" />

After:
<img width="721" height="149" alt="Screenshot 2025-08-28 at 21 43 31" src="https://github.com/user-attachments/assets/972199d2-0fd7-4f84-bf77-bb484e806fe0" />

The fix is also validated by a change in the parser test to the correct AST snapshot.