### PR TITLE
fix: Separate preprocessor macro signature from expansion

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -626,7 +626,24 @@ function parsePreprocessor(tokens: Token[]): PreprocessorStatement {
     name = consume(tokens).value
 
     if (name === 'define') {
-      const left = parseExpression(tokens)
+      const lhs = consume(tokens)
+      let left: Expression = { type: 'Identifier', name: lhs.value }
+      const next = tokens[0]
+
+      // Macro definition: #define foo(a, b, c) ...
+      if (next && next.value === '(') {
+        consume(tokens)
+
+        const args: Expression[] = []
+        while (tokens[0]?.value !== ')') {
+          args.push(parseExpression(tokens, 0))
+          if (tokens[0]?.value !== ')') consume(tokens, ',')
+        }
+        consume(tokens, ')')
+
+        left = { type: 'CallExpression', callee: left, arguments: args }
+      }
+
       if (tokens[0]?.value === '\\') value = [left]
       else value = [left, parseExpression(tokens)]
     } else if (name === 'extension') {

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -1001,5 +1001,149 @@ describe('parser', () => {
         value: null,
       },
     ])
+
+    expect(parse('#define union3(a, b, c) min(a, min(b, c))\n').body).toStrictEqual<[PreprocessorStatement]>([
+      {
+        name: 'define',
+        type: 'PreprocessorStatement',
+        value: [
+          {
+            arguments: [
+              {
+                name: 'a',
+                type: 'Identifier',
+              },
+              {
+                name: 'b',
+                type: 'Identifier',
+              },
+              {
+                name: 'c',
+                type: 'Identifier',
+              },
+            ],
+            callee: {
+              name: 'union3',
+              type: 'Identifier',
+            },
+            type: 'CallExpression',
+          },
+          {
+            arguments: [
+              {
+                name: 'a',
+                type: 'Identifier',
+              },
+              {
+                arguments: [
+                  {
+                    name: 'b',
+                    type: 'Identifier',
+                  },
+                  {
+                    name: 'c',
+                    type: 'Identifier',
+                  },
+                ],
+                callee: {
+                  name: 'min',
+                  type: 'Identifier',
+                },
+                type: 'CallExpression',
+              },
+            ],
+            callee: {
+              name: 'min',
+              type: 'Identifier',
+            },
+            type: 'CallExpression',
+          },
+        ],
+      },
+    ])
+
+    expect(parse('#define whiteComplement( a ) ( 1.0 - saturate( a ) )\n').body).toStrictEqual<[PreprocessorStatement]>(
+      [
+        {
+          name: 'define',
+          type: 'PreprocessorStatement',
+          value: [
+            {
+              arguments: [
+                {
+                  name: 'a',
+                  type: 'Identifier',
+                },
+              ],
+              callee: {
+                name: 'whiteComplement',
+                type: 'Identifier',
+              },
+              type: 'CallExpression',
+            },
+            {
+              left: {
+                type: 'Literal',
+                value: '1.0',
+              },
+              operator: '-',
+              right: {
+                arguments: [
+                  {
+                    name: 'a',
+                    type: 'Identifier',
+                  },
+                ],
+                callee: {
+                  name: 'saturate',
+                  type: 'Identifier',
+                },
+                type: 'CallExpression',
+              },
+              type: 'BinaryExpression',
+            },
+          ],
+        },
+      ],
+    )
+
+    expect(parse('#if defined( USE_UV ) || defined( USE_ANISOTROPY )\n').body).toStrictEqual<[PreprocessorStatement]>([
+      {
+        name: 'if',
+        type: 'PreprocessorStatement',
+        value: [
+          {
+            left: {
+              arguments: [
+                {
+                  name: 'USE_UV',
+                  type: 'Identifier',
+                },
+              ],
+              callee: {
+                name: 'defined',
+                type: 'Identifier',
+              },
+              type: 'CallExpression',
+            },
+            operator: '||',
+            right: {
+              arguments: [
+                {
+                  name: 'USE_ANISOTROPY',
+                  type: 'Identifier',
+                },
+              ],
+              callee: {
+                name: 'defined',
+                type: 'Identifier',
+              },
+              type: 'CallExpression',
+            },
+            type: 'LogicalExpression',
+          },
+        ],
+      },
+    ])
   })
 })


### PR DESCRIPTION
Before the changes, the following macro:
```glsl
#define whiteComplement(a) (1.0 - saturate(a))
```
... would be parsed as if the "return value" of `whiteComplement(a)` was called with the argument `1.0 - saturate(a)`.

This PR changes the way macro definitions are parsed, and adds new tests to validate this change.